### PR TITLE
create a show documentation action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ if (PLUGIN_PYTHON)
 
     AddPlugin(NAME ${PROJECT_NAME})
 
+    option(PLUGIN_PYTHON_COPY_ENV "Should the content of the current python venv be copied on install" ON)
+    mark_as_advanced(PLUGIN_PYTHON_COPY_ENV)
+
     # Qt's 'slots' conflicts with Python's 'slots'
     target_compile_definitions(PythonPlugin PRIVATE -DQT_NO_KEYWORDS)
 
@@ -21,10 +24,9 @@ if (PLUGIN_PYTHON)
     find_package(pybind11 CONFIG REQUIRED)
     find_package(Qt5 COMPONENTS WebEngineWidgets REQUIRED)
 
-    target_link_libraries(PythonPlugin pybind11::embed Qt5::WebEngineWidgets)
+    deploy_qt_copy(${PROJECT_NAME} ${CLOUDCOMPARE_DEST_FOLDER})
 
-    option(PLUGIN_PYTHON_COPY_ENV "Should the content of the current python venv be copied on install" ON)
-    mark_as_advanced(PLUGIN_PYTHON_COPY_ENV)
+    target_link_libraries(PythonPlugin pybind11::embed Qt5::WebEngineWidgets)
 
     set(CC_PYTHON_ENV_NAME "Python")
     set(CC_PLUGIN_INSTALL_DIR ${CLOUDCOMPARE_DEST_FOLDER}/plugins)
@@ -38,6 +40,14 @@ if (PLUGIN_PYTHON)
                 TARGETS pycc cccorelib
                 DESTINATION "${CC_PYTHON_INSTALL_DIR}/Lib/site-packages"
         )
+        #If the docs have benn buit we copy them in the install folder
+        if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/docs/_build/index.html")
+            install(
+                    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs/_build/
+                    DESTINATION ${CC_PYTHON_INSTALL_DIR}/docs
+            )
+        endif()
+
     endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ if (PLUGIN_PYTHON)
     add_subdirectory(QCodeEditor)
 
     find_package(pybind11 CONFIG REQUIRED)
-    target_link_libraries(PythonPlugin pybind11::embed)
+    find_package(Qt5 COMPONENTS WebEngineWidgets REQUIRED)
+
+    target_link_libraries(PythonPlugin pybind11::embed Qt5::WebEngineWidgets)
 
     option(PLUGIN_PYTHON_COPY_ENV "Should the content of the current python venv be copied on install" ON)
     mark_as_advanced(PLUGIN_PYTHON_COPY_ENV)

--- a/helpers.cmake
+++ b/helpers.cmake
@@ -27,3 +27,42 @@ function(copy_python_venv install_dir)
         message(WARNING "No Python Home found")
     endif ()
 endfunction()
+
+
+# TODO: This is very much like DeployQt found in cloudcompare's cmake folder
+#       however DeployQT only works for executable targets and not lib targets
+#       because it adds .exe or .app, I believe DeployQt can be modified to work with
+#       lib as targets, in the meantime we have our own similar thing
+function(deploy_qt_copy target dest)
+    get_target_property(qmake_location Qt5::qmake IMPORTED_LOCATION)
+    get_filename_component(qt5_bin_dir ${qmake_location} DIRECTORY)
+
+
+    find_program(win_deploy_qt windeployqt HINTS "${qt5_bin_dir}")
+
+    if (NOT EXISTS "${win_deploy_qt}")
+        message(FATAL_ERROR "windeployqt not found in ${qt5_bin_dir}")
+    endif ()
+
+    set(temp_dir "${CMAKE_CURRENT_BINARY_DIR}/deployqt")
+    add_custom_command(
+            TARGET ${PROJECT_NAME}
+            POST_BUILD
+            COMMAND "${win_deploy_qt}"
+            $<TARGET_FILE:${PROJECT_NAME}>
+            --no-angle
+            --no-opengl-sw
+            --no-quick-import
+            --no-system-d3d-compiler
+            --concurrent
+            --verbose=1
+            --dir ${temp_dir}
+            VERBATIM
+    )
+
+    install(
+            DIRECTORY ${temp_dir}/
+            DESTINATION ${dest}
+    )
+
+endfunction()

--- a/include/PythonPlugin.h
+++ b/include/PythonPlugin.h
@@ -22,6 +22,7 @@
 
 class QPythonEditor;
 class QListWidget;
+class QDocViewer;
 
 namespace ui
 {
@@ -67,16 +68,20 @@ class PythonPlugin : public QObject, public ccStdPluginInterface
   private:
     void showRepl();
     void showEditor();
+    void showDocumentation();
     void showAboutDialog();
     void executeEditorCode(const std::string &evalFileName, const std::string &code, QListWidget *output);
 
     ui::QPythonREPL *m_repl{nullptr};
     QPythonEditor *m_editor{nullptr};
+    QDocViewer *m_docView{nullptr};
+
 
     std::unique_ptr<PythonConfigPaths> m_pythonConfig{nullptr};
 
     /// Actions
     QAction *m_showEditor{nullptr};
     QAction *m_showREPL{nullptr};
+    QAction *m_showDoc{nullptr};
     QAction *m_showAboutDialog{nullptr};
 };

--- a/src/PythonPlugin.cpp
+++ b/src/PythonPlugin.cpp
@@ -41,6 +41,7 @@ class QDocViewer
     explicit QDocViewer(QWidget *parent = nullptr) : m_widget(parent)
     {
         m_widget.setMinimumSize(1280, 800);
+        m_widget.setWindowTitle(QStringLiteral("Python Plugin Documentation"));
 
         auto *layout = new QVBoxLayout;
         auto viewEngine = new QWebEngineView(&m_widget);
@@ -54,6 +55,7 @@ class QDocViewer
         QWebEngineSettings *settings = viewEngine->settings();
         settings->setAttribute(QWebEngineSettings::LocalContentCanAccessFileUrls, true);
         settings->setAttribute(QWebEngineSettings::LocalContentCanAccessRemoteUrls, false);
+
 
         QUrl url(QString("file:///%1/%2")
                      .arg(QApplication::applicationDirPath())


### PR DESCRIPTION
It uses QWebEngineView to render the static docs that must be bundled locally.

TODO:

- [x] Copy Qt ressources (icudtl.dat, qtwebengine_*) next to CloudCompare.exe at install time
- [x] Copy QtWebEngineProcess.exe next to CloudCompare.exe at install time
- [x] Copy the static html documentation site where the Browser expect it to be
- [ ] Maybe make that whole thing optional with a -DPLUGIN_PYTHON_LOCAL_DOC_VIEWER
