### PR TITLE
Centralize Python code execution

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,5 @@ AccessModifierOffset: -2
 SpaceBeforeParens: ControlStatements
 AllowShortLoopsOnASingleLine: false
 BreakBeforeBraces: Allman
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty

--- a/QCodeEditor/src/QPythonEditor.h
+++ b/QCodeEditor/src/QPythonEditor.h
@@ -33,15 +33,15 @@ class QMdiSubWindow;
 QT_END_NAMESPACE
 
 class ccMainAppInterface;
+class PythonInterpreter;
 
 class QPythonEditor : public QMainWindow, public Ui::QPythonEditor
 {
     Q_OBJECT
 
   public:
-    QPythonEditor();
+    QPythonEditor(PythonInterpreter *interpreter);
     void changeEvent(QEvent *e) override;
-    static QPythonEditor *TheInstance();
     bool openFile(const QString &fileName);
     static QString settingsApplicationName();
 
@@ -49,7 +49,7 @@ class QPythonEditor : public QMainWindow, public Ui::QPythonEditor
     void closeEvent(QCloseEvent *event) override;
   Q_SIGNALS:
     void
-    executionCalled(const std::string &evalFileName, const std::string &evalStatement, QListWidget *output);
+    executionCalled(const std::string &evalStatement, QListWidget *output);
 
   protected Q_SLOTS:
     void newFile();
@@ -71,6 +71,8 @@ class QPythonEditor : public QMainWindow, public Ui::QPythonEditor
     void about();
     void updateMenus();
     void updateWindowMenu();
+    void executionStarted();
+    void executionFinished();
     CodeEditor *createChildCodeEditor();
 
   private:

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,10 +4,12 @@ target_sources(${PROJECT_NAME}
         ${CMAKE_CURRENT_LIST_DIR}/AboutDialog.h
         ${CMAKE_CURRENT_LIST_DIR}/PrivateRuntime.h
         ${CMAKE_CURRENT_LIST_DIR}/PythonPlugin.h
+        ${CMAKE_CURRENT_LIST_DIR}/PythonInterpreter.h
         ${CMAKE_CURRENT_LIST_DIR}/QPythonREPL.h
         ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighter.h
         ${CMAKE_CURRENT_LIST_DIR}/Consoles.h
         ${CMAKE_CURRENT_LIST_DIR}/ccGUIPythonInstance.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/Utilities.h
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/include/PythonInterpreter.h
+++ b/include/PythonInterpreter.h
@@ -1,0 +1,106 @@
+//##########################################################################
+//#                                                                        #
+//#                CLOUDCOMPARE PLUGIN: PythonPlugin                       #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                   COPYRIGHT: Thomas Montaigu                           #
+//#                                                                        #
+//##########################################################################
+
+#ifndef CLOUDCOMPAREPROJECTS_PYTHONINTERPRETER_H
+#define CLOUDCOMPAREPROJECTS_PYTHONINTERPRETER_H
+
+#include <QObject>
+
+#include <memory>
+
+#include <ccLog.h>
+#include <pybind11/pybind11.h>
+
+class QListWidget;
+struct PyVenvCfg;
+
+/// Holds strings of the PythonHome & PythonPath
+/// Which are variables that needs to be properly set
+/// in order to have a functioning Python environment
+class PythonConfigPaths
+{
+  public:
+    /// Default ctor, does not initialize pythonHome & pythonPath
+    PythonConfigPaths() = default;
+
+    /// Initialize the paths to point to where the Python
+    /// environment was bundled on a Windows installation
+    static PythonConfigPaths WindowsBundled();
+
+    /// Initialize the paths to use the conda environment stored at condaPrefix
+    static PythonConfigPaths WindowsCondaEnv(const char *condaPrefix);
+
+    /// Initialize the paths to use the python venv stored at venvPrefix.
+    ///
+    /// \param venvPrefix Path on disk to the root of the venv
+    /// \param cfg options that were read from the pyvenv.cfg file
+    /// \return the configured paths
+    static PythonConfigPaths WindowsVenv(const char *venvPrefix, const PyVenvCfg &cfg);
+
+    /// returns true if both paths are non empty
+    bool isSet() const;
+
+    /// Returns the pythonHome
+    const wchar_t *pythonHome() const;
+
+    /// Returns the pythonPath
+    const wchar_t *pythonPath() const;
+
+  private:
+    std::unique_ptr<wchar_t[]> m_pythonHome{};
+    std::unique_ptr<wchar_t[]> m_pythonPath{};
+};
+
+class PythonInterpreter : public QObject
+{
+    Q_OBJECT
+
+  public:
+    struct State
+    {
+        State() : globals(pybind11::globals()), locals(){};
+        pybind11::dict globals;
+        pybind11::dict locals;
+    };
+
+  public:
+    explicit PythonInterpreter(QObject *parent = nullptr);
+    bool isExecuting() const;
+    void initialize();
+    static bool isInitialized();
+    static void finalize();
+
+    bool executeFile(const std::string& filePath);
+
+  public Q_SLOTS:
+    void executeCode(const std::string &code, QListWidget *output);
+    void executeCodeWithState(const std::string &code, QListWidget *output, State &state);
+
+  Q_SIGNALS:
+    void executionStarted();
+    void executionFinished();
+
+  private:
+    void configureEnvironment();
+
+  private:
+    bool m_isExecuting{false};
+
+    PythonConfigPaths m_config;
+};
+
+#endif // CLOUDCOMPAREPROJECTS_PYTHONINTERPRETER_H

--- a/include/PythonPlugin.h
+++ b/include/PythonPlugin.h
@@ -20,6 +20,8 @@
 #include "ccStdPluginInterface.h"
 #include <memory>
 
+#include "PythonInterpreter.h"
+
 class QPythonEditor;
 class QListWidget;
 class QDocViewer;
@@ -29,55 +31,6 @@ namespace ui
 class QPythonREPL;
 }
 
-struct Version {
-    constexpr Version() = default;
-
-    constexpr Version(uint16_t major, uint16_t minor, uint16_t patch);
-
-    explicit Version(const QStringRef& versionStr);
-
-    bool operator==(const Version& other) const;
-
-    uint16_t major{0};
-    uint16_t minor{0};
-    uint16_t patch{0};
-};
-
-struct PyVenvCfg
-{
-    PyVenvCfg() = default;
-
-    static PyVenvCfg FromFile(const QString &path);
-
-    QString home{};
-    bool includeSystemSitesPackages{};
-    Version version;
-};
-
-/// Holds strings of the PythonHome & PythonPath
-/// Which are variables that needs to be properly set
-/// in order to have a functioning Python environment
-class PythonConfigPaths
-{
-  public:
-    PythonConfigPaths() = default;
-
-    static PythonConfigPaths WindowsBundled();
-
-    static PythonConfigPaths WindowsCondaEnv(const char * condaPrefix);
-
-    static PythonConfigPaths WindowsVenv(const char *venvPrefix, const PyVenvCfg& cfg);
-
-    bool isSet() const { return m_pythonHome != nullptr && m_pythonPath != nullptr; }
-
-    const wchar_t *pythonHome() const { return m_pythonHome.get(); }
-
-    const wchar_t *pythonPath() const { return m_pythonPath.get(); }
-
-  private:
-    std::unique_ptr<wchar_t[]> m_pythonHome{};
-    std::unique_ptr<wchar_t[]> m_pythonPath{};
-};
 
 /// "Entry point" of the plugin
 class PythonPlugin : public QObject, public ccStdPluginInterface
@@ -98,22 +51,19 @@ class PythonPlugin : public QObject, public ccStdPluginInterface
     /// CloudCompare's commandline mode
     void registerCommands(ccCommandLineInterface *cmd) override;
 
+    void setMainAppInterface(ccMainAppInterface *app) override;
+
   private:
     void showRepl();
     void showEditor();
     void showDocumentation();
     void showAboutDialog();
-    void executeEditorCode(const std::string &evalFileName, const std::string &code, QListWidget *output);
-    void configurePython();
 
-
+    PythonInterpreter m_interp;
 
     ui::QPythonREPL *m_repl{nullptr};
     QPythonEditor *m_editor{nullptr};
     QDocViewer *m_docView{nullptr};
-
-
-    PythonConfigPaths m_pythonConfig{};
 
     /// Actions
     QAction *m_showEditor{nullptr};

--- a/include/QPythonREPL.h
+++ b/include/QPythonREPL.h
@@ -18,16 +18,16 @@
 #ifndef CLOUDCOMPAREPROJECTS_QPYTHONREPL_H
 #define CLOUDCOMPAREPROJECTS_QPYTHONREPL_H
 
-#include <QtWidgets>
 #include <QMainWindow>
+#include <QtWidgets>
 
 #include <string>
 
-#include "PythonStdErrOutRedirect.h"
-#include <pybind11/pybind11.h>
+#include "PythonInterpreter.h"
 
 namespace py = pybind11;
 
+class PythonInterpreter;
 class Ui_QPythonREPL;
 
 namespace ui
@@ -76,14 +76,14 @@ class QPythonREPL : public QMainWindow
     Q_OBJECT
 
   public:
-    explicit QPythonREPL(QMainWindow *parent = nullptr);
+    explicit QPythonREPL(PythonInterpreter *interpreter, QMainWindow *parent = nullptr);
 
     void executeCode(const QString &pythonCode);
+
     ~QPythonREPL() override;
 
   protected:
     QPlainTextEdit *codeEdit();
-
     QListWidget *outputDisplay();
 
     void reset();
@@ -93,9 +93,9 @@ class QPythonREPL : public QMainWindow
   private:
     History m_history{};
     std::string m_buf;
-    py::object m_output;
-    py::dict m_locals;
-    Ui_QPythonREPL *m_ui;
+    Ui_QPythonREPL *m_ui{nullptr};
+    PythonInterpreter *m_interpreter{nullptr};
+    PythonInterpreter::State m_state;
 };
 
 } // namespace ui

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -1,0 +1,32 @@
+//##########################################################################
+//#                                                                        #
+//#                CLOUDCOMPARE PLUGIN: PythonPlugin                       #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                   COPYRIGHT: Thomas Montaigu                           #
+//#                                                                        #
+//##########################################################################
+
+#ifndef CLOUDCOMPAREPROJECTS_UTILITIES_H
+#define CLOUDCOMPAREPROJECTS_UTILITIES_H
+
+#include <QString>
+
+/// Returns a newly allocated array (null terminated) from a QString
+inline wchar_t *QStringToWcharArray(const QString &string)
+{
+    auto *wcharArray = new wchar_t[string.size() + 1];
+    int len = string.toWCharArray(wcharArray);
+    Q_ASSERT(len <= string.size());
+    wcharArray[len] = '\0';
+    return wcharArray;
+}
+#endif // CLOUDCOMPAREPROJECTS_UTILITIES_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${PROJECT_NAME}
         ${CMAKE_CURRENT_LIST_DIR}/AboutDialog.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Runtime.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PythonPlugin.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/PythonInterpreter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/QPythonREPL.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ccGUIPythonInstance.cpp

--- a/src/PythonInterpreter.cpp
+++ b/src/PythonInterpreter.cpp
@@ -1,0 +1,378 @@
+//##########################################################################
+//#                                                                        #
+//#                CLOUDCOMPARE PLUGIN: PythonPlugin                       #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                   COPYRIGHT: Thomas Montaigu                           #
+//#                                                                        #
+//##########################################################################
+
+#include "PythonInterpreter.h"
+#include "PythonStdErrOutRedirect.h"
+#include "Utilities.h"
+
+#include <pybind11/embed.h>
+
+#include <QApplication>
+#include <QDir>
+#include <QListWidgetItem>
+#include <QProcess>
+#include <QTextCodec>
+
+#include <ccLog.h>
+
+namespace py = pybind11;
+
+//================================================================================
+
+struct Version
+{
+    constexpr Version() = default;
+
+    constexpr Version(uint16_t major, uint16_t minor, uint16_t patch);
+
+    explicit Version(const QStringRef &versionStr);
+
+    bool operator==(const Version &other) const;
+
+    uint16_t major{0};
+    uint16_t minor{0};
+    uint16_t patch{0};
+};
+
+constexpr Version::Version(uint16_t major_, uint16_t minor_, uint16_t patch_)
+    : major(major_), minor(minor_), patch(patch_)
+{
+}
+
+Version::Version(const QStringRef &versionStr) : Version()
+{
+
+    QVector<QStringRef> parts = versionStr.split('.');
+    if (parts.size() == 3)
+    {
+        major = parts[0].toUInt();
+        minor = parts[1].toUInt();
+        patch = parts[2].toUInt();
+    }
+}
+
+bool Version::operator==(const Version &other) const
+{
+    return major == other.major && minor == other.minor && patch == other.patch;
+}
+
+constexpr Version PythonVersion(PY_MAJOR_VERSION, PY_MINOR_VERSION, PY_MICRO_VERSION);
+
+//================================================================================
+
+struct PyVenvCfg
+{
+    PyVenvCfg() = default;
+
+    static PyVenvCfg FromFile(const QString &path);
+
+    QString home{};
+    bool includeSystemSitesPackages{};
+    Version version;
+};
+
+PyVenvCfg PyVenvCfg::FromFile(const QString &path)
+{
+    PyVenvCfg cfg{};
+
+    QFile cfgFile(path);
+    if (cfgFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        while (!cfgFile.atEnd())
+        {
+            QString line = cfgFile.readLine();
+            QStringList v = line.split("=");
+
+            if (v.size() == 2)
+            {
+                QString name = v[0].simplified();
+                QString value = v[1].simplified();
+
+                if (name == "home")
+                {
+                    cfg.home = value;
+                }
+                else if (name == "include-system-site-packages")
+                {
+                    cfg.includeSystemSitesPackages = (value == "true");
+                }
+                else if (name == "version")
+                {
+                    cfg.version = Version(QStringRef(&value));
+                }
+            }
+        }
+    }
+
+    return cfg;
+}
+
+Version GetPythonExeVersion(const QString &pythonExePath)
+{
+    QProcess pythonProcess;
+    pythonProcess.start(pythonExePath, {"--version"});
+    pythonProcess.waitForFinished();
+
+    QString versionStr = QTextCodec::codecForName("utf-8")->toUnicode(pythonProcess.readAllStandardOutput());
+
+    QVector<QStringRef> splits = versionStr.splitRef(" ");
+    if (splits.size() == 2 && splits[0].contains("Python"))
+    {
+        return Version(splits[1]);
+    }
+    return Version{};
+}
+
+//================================================================================
+
+PythonConfigPaths PythonConfigPaths::WindowsBundled()
+{
+    PythonConfigPaths config{};
+
+    QDir pythonEnvDirPath(QApplication::applicationDirPath() + "/plugins/Python");
+    if (pythonEnvDirPath.exists())
+    {
+        QString qPythonHome = pythonEnvDirPath.path();
+        config.m_pythonHome.reset(QStringToWcharArray(qPythonHome));
+
+        QString qPythonPath = QString("%1/DLLs;%1/lib;%1/Lib/site-packages;").arg(qPythonHome);
+        config.m_pythonPath.reset(QStringToWcharArray(qPythonPath));
+    }
+    else
+    {
+        throw std::runtime_error("Python environment not found, plugin wasn't correctly installed");
+    }
+    return config;
+}
+
+PythonConfigPaths PythonConfigPaths::WindowsCondaEnv(const char *condaPrefix)
+{
+    PythonConfigPaths config{};
+
+    QDir pythonEnvDirPath(condaPrefix);
+    if (pythonEnvDirPath.exists())
+    {
+        QString qPythonHome = pythonEnvDirPath.path();
+        config.m_pythonHome.reset(QStringToWcharArray(qPythonHome));
+
+        QString qPythonPath =
+            QString("%1/DLLs;%1/lib;%1/Lib/site-packages;%2/plugins/Python/Lib/site-packages")
+                .arg(qPythonHome)
+                .arg(QApplication::applicationDirPath());
+        config.m_pythonPath.reset(QStringToWcharArray(qPythonPath));
+    }
+    else
+    {
+        throw std::runtime_error("Python environment not found, plugin wasn't correctly installed");
+    }
+    return config;
+}
+
+PythonConfigPaths PythonConfigPaths::WindowsVenv(const char *venvPrefix, const PyVenvCfg &cfg)
+{
+    PythonConfigPaths config{};
+
+    QDir pythonEnvDirPath(venvPrefix);
+    if (pythonEnvDirPath.exists())
+    {
+        QString qPythonHome = pythonEnvDirPath.path();
+        config.m_pythonHome.reset(QStringToWcharArray(qPythonHome));
+
+        QString qPythonPath =
+            QString("%1/Lib/site-packages;%2/plugins/Python/Lib/site-packages;%3/DLLS;%3/lib")
+                .arg(qPythonHome)
+                .arg(QApplication::applicationDirPath())
+                .arg(cfg.home);
+
+        if (cfg.includeSystemSitesPackages)
+        {
+            qPythonPath.append(QString("%1/Lib/site-packages").arg(cfg.home));
+        }
+        config.m_pythonPath.reset(QStringToWcharArray(qPythonPath));
+    }
+    else
+    {
+        throw std::runtime_error("Python environment not found, plugin wasn't correctly installed");
+    }
+    return config;
+}
+
+bool PythonConfigPaths::isSet() const
+{
+    return m_pythonHome != nullptr && m_pythonPath != nullptr;
+}
+
+const wchar_t *PythonConfigPaths::pythonHome() const
+{
+    return m_pythonHome.get();
+}
+
+const wchar_t *PythonConfigPaths::pythonPath() const
+{
+    return m_pythonPath.get();
+}
+
+//================================================================================
+
+PythonInterpreter::PythonInterpreter(QObject *parent) : QObject(parent) {}
+
+bool PythonInterpreter::executeFile(const std::string& filepath)
+{
+    if (m_isExecuting)
+    {
+        return false;
+    }
+    Q_EMIT executionStarted();
+
+    bool success{true};
+    try
+    {
+        PyStdErrOutStreamRedirect r{};
+        py::eval_file(filepath);
+    }
+    catch (const std::exception &e)
+    {
+        ccLog::Warning(e.what());
+        success = false;
+    }
+
+    Q_EMIT executionFinished();
+    return success;
+}
+
+void PythonInterpreter::executeCodeWithState(const std::string &code, QListWidget *output, State &state)
+{
+    Q_ASSERT(output != nullptr);
+    if (m_isExecuting)
+    {
+        return;
+    }
+
+    Q_EMIT executionStarted();
+    m_isExecuting = true;
+
+    try
+    {
+        py::object o = py::module::import("ccinternals").attr("ConsoleREPL")(output);
+        PyStdErrOutStreamRedirect redirect{o, o};
+        py::exec(code);
+    }
+    catch (const std::exception &e)
+    {
+        auto message = new QListWidgetItem(e.what());
+        message->setTextColor(Qt::red);
+        output->addItem(message);
+    }
+
+    m_isExecuting = false;
+    Q_EMIT executionFinished();
+}
+
+void PythonInterpreter::executeCode(const std::string &code, QListWidget *output)
+{
+    State tmpState;
+    executeCodeWithState(code, output, tmpState);
+}
+
+void PythonInterpreter::initialize()
+{
+    configureEnvironment();
+    Py_SetPythonHome(m_config.pythonHome());
+    Py_SetPath(m_config.pythonPath());
+
+    py::initialize_interpreter();
+}
+
+bool PythonInterpreter::isInitialized()
+{
+    return Py_IsInitialized();
+}
+
+void PythonInterpreter::finalize()
+{
+    if (Py_IsInitialized())
+    {
+        py::finalize_interpreter();
+    }
+}
+
+void PythonInterpreter::configureEnvironment()
+{
+    const char *condaPrefix = std::getenv("CONDA_PREFIX");
+    const char *venvPrefix = std::getenv("VIRTUAL_ENV");
+    if (condaPrefix)
+    {
+        ccLog::Print("[PythonPlugin] Conda environment detected (%s)", std::getenv("CONDA_DEFAULT_ENV"));
+        QString pythonExePath = QString(condaPrefix) + "/python.exe";
+        if (!QFile::exists(pythonExePath))
+        {
+            pythonExePath = "python";
+        }
+
+        Version condaPythonVersion = GetPythonExeVersion(pythonExePath);
+        if (condaPythonVersion == PythonVersion)
+        {
+            m_config = PythonConfigPaths::WindowsCondaEnv(condaPrefix);
+        }
+        else
+        {
+            ccLog::Warning("[PythonPlugin] Conda environment's Python version (%u.%u.%u)"
+                           " does not match the plugin expected version (%u.%u.%u)",
+                           condaPythonVersion.major,
+                           condaPythonVersion.minor,
+                           condaPythonVersion.patch,
+                           PythonVersion.major,
+                           PythonVersion.minor,
+                           PythonVersion.patch);
+        }
+    }
+    else if (venvPrefix)
+    {
+        ccLog::Print("[PythonPlugin] Virtual environment detected");
+        PyVenvCfg cfg = PyVenvCfg::FromFile(QString("%1/pyvenv.cfg").arg(venvPrefix));
+        if (cfg.version == PythonVersion)
+        {
+            m_config = PythonConfigPaths::WindowsVenv(venvPrefix, cfg);
+        }
+        else
+        {
+            ccLog::Warning("[PythonPlugin] venv's Python version (%u.%u.%u)"
+                           " does not match the plugin expected version (%u.%u.%u)",
+                           cfg.version.major,
+                           cfg.version.minor,
+                           cfg.version.patch,
+                           PythonVersion.major,
+                           PythonVersion.minor,
+                           PythonVersion.patch);
+        }
+    }
+
+    if (!m_config.isSet())
+    {
+        if (condaPrefix || venvPrefix)
+        {
+            ccLog::Warning("Something went wrong using custom environment configuration"
+                           " falling back to bundled Python environment");
+        }
+        m_config = PythonConfigPaths::WindowsBundled();
+    }
+}
+
+bool PythonInterpreter::isExecuting() const
+{
+    return m_isExecuting;
+}

--- a/src/ccGUIPythonInstance.cpp
+++ b/src/ccGUIPythonInstance.cpp
@@ -17,7 +17,6 @@
 
 #include "ccGUIPythonInstance.h"
 
-#include <FileIOFilter.h>
 
 #define slots Q_SLOTS
 #define signals Q_SIGNALS


### PR DESCRIPTION
Add a PythonInterpreter class inheriting from Object.
This class centralizes the execution of Python code, and we use it to make sure that only one script can be executed at once.