### PR TITLE
Switch to using embedded modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,17 @@ if (PLUGIN_PYTHON)
     option(PLUGIN_PYTHON_COPY_ENV "Should the content of the current python venv be copied on install" ON)
     mark_as_advanced(PLUGIN_PYTHON_COPY_ENV)
 
-    # Qt's 'slots' conflicts with Python's 'slots'
-    target_compile_definitions(PythonPlugin PRIVATE -DQT_NO_KEYWORDS)
-
-    add_subdirectory(wrapper)
+    set(USE_EMBEDDED_MODULES ON)
+    target_compile_definitions(PythonPlugin PRIVATE  -DUSE_EMBEDDED_MODULES)
+    include(wrapper/cccorelib/CMakeLists.txt)
+    include(wrapper/pycc/CMakeLists.txt)
 
     add_subdirectory(include)
     add_subdirectory(src)
     add_subdirectory(ui)
+
+    embed_cccorelib_in(${PROJECT_NAME})
+    embed_pycc_in(${PROJECT_NAME})
 
     add_subdirectory(QCodeEditor)
 
@@ -36,10 +39,6 @@ if (PLUGIN_PYTHON)
         if (PLUGIN_PYTHON_COPY_ENV)
             copy_python_venv(${CC_PYTHON_INSTALL_DIR})
         endif()
-        INSTALL(
-                TARGETS pycc cccorelib
-                DESTINATION "${CC_PYTHON_INSTALL_DIR}/Lib/site-packages"
-        )
         # If the docs have been built, we copy them in the install folder
         if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/docs/_build/index.html")
             install(
@@ -47,7 +46,6 @@ if (PLUGIN_PYTHON)
                     DESTINATION ${CC_PYTHON_INSTALL_DIR}/docs
             )
         endif()
-
     endif ()
 endif ()
 

--- a/include/PythonInterpreter.h
+++ b/include/PythonInterpreter.h
@@ -22,6 +22,7 @@
 
 #include <memory>
 
+#undef slots
 #include <pybind11/pybind11.h>
 
 class QListWidget;

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -19,6 +19,7 @@
 
 #include <ui_AboutDialog.h>
 
+#undef slots
 #include <pybind11/pybind11.h>
 
 

--- a/src/PythonInterpreter.cpp
+++ b/src/PythonInterpreter.cpp
@@ -170,9 +170,8 @@ PythonConfigPaths PythonConfigPaths::WindowsCondaEnv(const char *condaPrefix)
         config.m_pythonHome.reset(QStringToWcharArray(qPythonHome));
 
         QString qPythonPath =
-            QString("%1/DLLs;%1/lib;%1/Lib/site-packages;%2/plugins/Python/Lib/site-packages")
-                .arg(qPythonHome)
-                .arg(QApplication::applicationDirPath());
+            QString("%1/DLLs;%1/lib;%1/Lib/site-packages")
+                .arg(qPythonHome);
         config.m_pythonPath.reset(QStringToWcharArray(qPythonPath));
     }
     else
@@ -193,9 +192,8 @@ PythonConfigPaths PythonConfigPaths::WindowsVenv(const char *venvPrefix, const P
         config.m_pythonHome.reset(QStringToWcharArray(qPythonHome));
 
         QString qPythonPath =
-            QString("%1/Lib/site-packages;%2/plugins/Python/Lib/site-packages;%3/DLLS;%3/lib")
+            QString("%1/Lib/site-packages;%3/DLLS;%3/lib")
                 .arg(qPythonHome)
-                .arg(QApplication::applicationDirPath())
                 .arg(cfg.home);
 
         if (cfg.includeSystemSitesPackages)

--- a/wrapper/cccorelib/CMakeLists.txt
+++ b/wrapper/cccorelib/CMakeLists.txt
@@ -1,55 +1,64 @@
-cmake_minimum_required(VERSION 3.12)
-project(cccorelib)
-
-set(CMAKE_CXX_STANDARD 14)
-
-find_package(pybind11 CONFIG REQUIRED)
-
-pybind11_add_module(cccorelib
-        src/cccorelib.cpp
-        src/cccorelib.h
-        src/AutoSegmentationTools.cpp
-        src/BoundingBox.cpp
-        src/CCGeom.cpp
-        src/CCMath.cpp
-        src/CCConst.cpp
-        src/CCMiscTools.cpp
-        src/CCShareable.cpp
-        src/CloudSamplingTools.cpp
-        src/GenericIndexedCloudPersist.cpp
-        src/PointCloud.cpp
-        src/GenericOctree.cpp
-        src/ChamferDistanceTransform.cpp
-        src/DgmOctree.cpp
-        src/DgmOctreeReferenceCloud.cpp
-        src/GenericCloud.cpp
-        src/GenericIndexedCloud.cpp
-        src/GenericProgressCallback.cpp
-        src/GeometricalAnalysisTools.cpp
-        src/TrueKdTree.cpp
-        src/StatisticalTestingTools.cpp
-        src/GenericDistribution.cpp
-        src/GenericTriangle.cpp
-        src/SimpleTriangle.cpp
-        src/GenericMesh.cpp
-        src/GenericIndexedMesh.cpp
-        src/SimpleMesh.cpp
-        src/KdTree.cpp
-        src/LocalModel.cpp
-        src/WeibullDistribution.cpp
-        src/ScalarFieldTools.cpp
-        src/ScalarField.cpp
-        src/RegistrationTools.cpp
-        src/ReferenceCloud.cpp
-        src/Polyline.cpp
-        src/PointProjectionTools.cpp
-        src/ManualSegmentationTools.cpp
-        src/NormalDistribution.cpp
-        src/Delaynay2dMesh.cpp
-        src/ErrorFunction.cpp
-        src/FastMarching.cpp
-        src/DistanceComputationTools.cpp
-        src/wrappers.h
-        src/casters.h
+set(cccorelib_sources
+        ${CMAKE_CURRENT_LIST_DIR}/src/cccorelib.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/cccorelib.h
+        ${CMAKE_CURRENT_LIST_DIR}/src/AutoSegmentationTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/BoundingBox.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CCGeom.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CCMath.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CCConst.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CCMiscTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CCShareable.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/CloudSamplingTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericIndexedCloudPersist.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/PointCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericOctree.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ChamferDistanceTransform.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/DgmOctree.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/DgmOctreeReferenceCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericIndexedCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericProgressCallback.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GeometricalAnalysisTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/TrueKdTree.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/StatisticalTestingTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericDistribution.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericTriangle.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/SimpleTriangle.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericMesh.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/GenericIndexedMesh.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/SimpleMesh.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/KdTree.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/LocalModel.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/WeibullDistribution.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ScalarFieldTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ScalarField.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/RegistrationTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ReferenceCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/Polyline.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/PointProjectionTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ManualSegmentationTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/NormalDistribution.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/Delaynay2dMesh.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ErrorFunction.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/FastMarching.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/DistanceComputationTools.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/wrappers.h
+        ${CMAKE_CURRENT_LIST_DIR}/src/casters.h
         )
-target_link_libraries(cccorelib PRIVATE CCCoreLib)
+
+if (NOT USE_EMBEDDED_MODULES)
+    cmake_minimum_required(VERSION 3.12)
+    project(cccorelib)
+
+    set(CMAKE_CXX_STANDARD 14)
+
+    find_package(pybind11 CONFIG REQUIRED)
+
+    pybind11_add_module(cccorelib ${cccorelib_source})
+    target_link_libraries(cccorelib PRIVATE CCCoreLib)
+else ()
+    function(embed_cccorelib_in target)
+        target_sources(${target} PRIVATE ${cccorelib_sources})
+        target_link_libraries(${target} CCCoreLib)
+    endfunction(embed_cccorelib_in)
+endif ()

--- a/wrapper/cccorelib/src/cccorelib.cpp
+++ b/wrapper/cccorelib/src/cccorelib.cpp
@@ -223,8 +223,7 @@ class NumpyCloud : public CCCoreLib::GenericIndexedCloud
     py::array_t<PointCoordinateType> m_zs;
 };
 
-PYBIND11_MODULE(cccorelib, m)
-{
+void define_cccorelib(py::module& m) {
     py::bind_vector<CCCoreLib::ReferenceCloudContainer>(m, "ReferenceCloudContainer");
 
     define_CCShareable(m);
@@ -297,3 +296,16 @@ PYBIND11_MODULE(cccorelib, m)
     // SaitoSquared...
     // SquareMatrix
 }
+
+#ifdef USE_EMBEDDED_MODULES
+#include <pybind11/embed.h>
+PYBIND11_EMBEDDED_MODULE(cccorelib, m)
+{
+    define_cccorelib(m);
+}
+#else
+PYBIND11_MODULE(cccorelib, m)
+{
+    define_cccorelib(m);
+}
+#endif

--- a/wrapper/pycc/CMakeLists.txt
+++ b/wrapper/pycc/CMakeLists.txt
@@ -1,21 +1,31 @@
-cmake_minimum_required(VERSION 3.12)
-project(pycc)
-
-set(CMAKE_CXX_STANDARD 11)
-
-find_package(pybind11 CONFIG REQUIRED)
-
-pybind11_add_module(
-        pycc
-        src/pycc.cpp
-        src/ccGUIPythonInstance.cpp
-        src/ccCommandLine.cpp
-        src/casters.h
-        src/ccDrawableObject.cpp
-        src/ccScalarField.cpp
-        src/ccObject.cpp
-        src/ccGenericPointCloud.cpp
-        src/ccPointCloud.cpp
+set(pycc_sources
+        ${CMAKE_CURRENT_LIST_DIR}/src/pycc.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccGUIPythonInstance.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccCommandLine.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/casters.h
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccDrawableObject.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccScalarField.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccObject.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccGenericPointCloud.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/src/ccPointCloud.cpp
 )
-target_link_libraries(pycc PRIVATE QCC_DB_LIB PythonPlugin)
-target_include_directories(pycc PRIVATE ../../include)
+
+if (NOT USE_EMBEDDED_MODULES)
+    cmake_minimum_required(VERSION 3.12)
+    project(pycc)
+
+    set(CMAKE_CXX_STANDARD 14)
+
+    find_package(pybind11 CONFIG REQUIRED)
+
+    pybind11_add_module(pycc ${pycc_sources})
+    target_link_libraries(pycc PRIVATE QCC_DB_LIB PythonPlugin)
+    target_include_directories(pycc PRIVATE ../../include)
+else()
+    function(embed_pycc_in target)
+        target_sources(${target} PRIVATE ${pycc_sources})
+        target_link_libraries(${target} QCC_DB_LIB)
+    endfunction(embed_pycc_in)
+endif()
+
+

--- a/wrapper/pycc/src/casters.h
+++ b/wrapper/pycc/src/casters.h
@@ -18,9 +18,11 @@
 #ifndef CLOUDCOMPAREPROJECTS_CASTERS_H
 #define CLOUDCOMPAREPROJECTS_CASTERS_H
 
-#include <Python.h>
 #include <QString>
+
+#undef slots
 #include <pybind11/pybind11.h>
+#include <Python.h>
 
 namespace pybind11
 {

--- a/wrapper/pycc/src/ccPointCloud.cpp
+++ b/wrapper/pycc/src/ccPointCloud.cpp
@@ -15,14 +15,16 @@
 //#                                                                        #
 //##########################################################################
 
-#include <pybind11/functional.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl_bind.h>
 
 #include "casters.h"
 #include <ccPointCloud.h>
 #include <ccScalarField.h>
+
+#undef slots
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 namespace py = pybind11;
 using namespace pybind11::literals;


### PR DESCRIPTION
Use embeded modules for pycc & cccorelib.

This simplifies installing the Plugin as the modules are Bundled within the plugin, so we don't need to care about copying them at install and we don't need to
setup the python path at runtime to be able to load them. This should greatly simplify installation on unixes

Keep the ability to build them as independent modules
as it might be need later to be able to do 'pip installable modules'

(The cmake written to the changes might not be the best possible)