### PR TITLE
Finalize the interpreter when aboutToQuit is received

### DIFF
--- a/include/PythonPlugin.h
+++ b/include/PythonPlugin.h
@@ -49,6 +49,7 @@ class PythonPlugin : public QObject, public ccStdPluginInterface
     void setMainAppInterface(ccMainAppInterface *app) override;
 
   private:
+    void finalizeInterpreter();
     void showRepl();
     void showEditor();
     void showAboutDialog();


### PR DESCRIPTION
Between 2.5.0 and 2.6.0 pybind11 added a function to clean the types it
registered (commit 6364b732e9e30cbd79b795e9290bfa3360aa32a1).

This is called by the Python interpreter during Py_Finalize, however
it caused CloudCompare to do a diry exit (when the plugin was compiled
with pybind11 >=2.6.0) as cc would crash during this cleanup function.

Strangely, removing all py::bind_vector<SomeType> from cccorelib made
the crash go away, but these bindings are needed so we don't remove them.

There was 2 option to work around the issue:

1) Comment out the call to the interpreter finalization function
as in the end, the plugin gets unloaded when CC is quitting, so the
OS would eventually clean after CC.

2) Find another time to call the finalization function, as maybe
calling during the PythonPlugin destructor may cause strange interactions
and when aboutToQuit is received seems like a good place to finalize stuff.