### PR TITLE
Editor settings

### DIFF
--- a/QCodeEditor/src/CodeEditor.h
+++ b/QCodeEditor/src/CodeEditor.h
@@ -89,9 +89,10 @@ class CodeEditor : public QPlainTextEdit
     bool isUntitled{true};
     QWidget *lineNumberArea{nullptr};
     QEditorSettings *settings{nullptr};
+    PythonHighlighter *highlighter;
 };
 
-class LineNumberArea : public QWidget
+class LineNumberArea final : public QWidget
 {
   public:
     explicit LineNumberArea(CodeEditor *editor) : QWidget(editor)
@@ -101,7 +102,7 @@ class LineNumberArea : public QWidget
 
     QSize sizeHint() const override
     {
-        return QSize(codeEditor->lineNumberAreaWidth(), 0);
+        return {codeEditor->lineNumberAreaWidth(), 0};
     }
 
   protected:

--- a/QCodeEditor/src/QEditorSettings.cpp
+++ b/QCodeEditor/src/QEditorSettings.cpp
@@ -16,20 +16,106 @@
 //##########################################################################
 
 #include "QEditorSettings.h"
-#include <ccLog.h>
 
-QEditorSettings::QEditorSettings() : Ui::QEditorSettings()
+#include <QPushButton>
+#include <QSettings>
+
+static const auto SHOULD_HIGHLIGHT_SETTINGS_KEY = QStringLiteral("ShouldHighlightCurrentLine");
+static const auto COLOR_SCHEME_SETTINGS_KEY = QStringLiteral("ColorSchemeName");
+
+static const QString SettingsScopeName()
 {
-    this->setupUi(this);
-    connectSignals();
+    return QCoreApplication::applicationName().append(":PythonPlugin.Editor");
 }
 
-int QEditorSettings::fontSize() const { return this->fontSizeSpinBox->value(); }
-
-void QEditorSettings::connectSignals()
+QEditorSettings::QEditorSettings() : QDialog(), Ui::QEditorSettings()
 {
-    connect(this->fontSizeSpinBox, qOverload<int>(&QSpinBox::valueChanged), this, [this](int _newValue) {
-        ccLog::Print("The value changed to %d", _newValue);
-        Q_EMIT settingsChanged();
-    });
+    setupUi();
+    connectSignals();
+    loadFromSettings();
+}
+
+void QEditorSettings::setupUi()
+{
+    Ui_QEditorSettings::setupUi(this);
+    for (const ColorScheme &colorScheme : ColorScheme::AvailableColorSchemes())
+    {
+        colorSchemeComboBox->addItem(colorScheme.name());
+    }
+}
+
+int QEditorSettings::fontSize() const
+{
+    return this->fontSizeSpinBox->value();
+}
+
+bool QEditorSettings::shouldHighlightCurrentLine() const
+{
+    return m_shouldHighlightCurrentLine;
+}
+
+const ColorScheme &QEditorSettings::colorScheme() const
+{
+    return m_colorScheme;
+}
+
+void QEditorSettings::saveChanges()
+{
+    const auto *colorScheme = ColorScheme::ColorSchemeByName(colorSchemeComboBox->currentText());
+    Q_ASSERT(colorScheme != nullptr);
+    m_colorScheme = *colorScheme;
+    m_shouldHighlightCurrentLine = highlightCurrentLineCheckBox->isChecked();
+
+    QSettings savedSettings(QCoreApplication::organizationName(), SettingsScopeName());
+    savedSettings.setValue(COLOR_SCHEME_SETTINGS_KEY, m_colorScheme.name());
+    savedSettings.setValue(SHOULD_HIGHLIGHT_SETTINGS_KEY, m_shouldHighlightCurrentLine);
+
+    Q_EMIT settingsChanged();
+}
+
+void QEditorSettings::saveChangesAndClose()
+{
+    saveChanges();
+    close();
+}
+
+void QEditorSettings::cancel()
+{
+    setFormValuesToCurrentValues();
+    close();
+}
+
+void QEditorSettings::setFormValuesToCurrentValues() const
+{
+    highlightCurrentLineCheckBox->setChecked(m_shouldHighlightCurrentLine);
+    colorSchemeComboBox->setCurrentText(m_colorScheme.name());
+}
+
+void QEditorSettings::loadFromSettings()
+{
+    const QSettings savedSettings(QCoreApplication::organizationName(), SettingsScopeName());
+
+    QVariant value = savedSettings.value(COLOR_SCHEME_SETTINGS_KEY);
+    const auto *colorScheme = ColorScheme::ColorSchemeByName(value.toString());
+    if (colorScheme)
+    {
+        m_colorScheme = *colorScheme;
+    }
+
+    if (savedSettings.contains(SHOULD_HIGHLIGHT_SETTINGS_KEY))
+    {
+        value = savedSettings.value(SHOULD_HIGHLIGHT_SETTINGS_KEY);
+        m_shouldHighlightCurrentLine = value.toBool();
+    }
+    setFormValuesToCurrentValues();
+}
+
+void QEditorSettings::connectSignals() const
+{
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QEditorSettings::saveChangesAndClose);
+    connect(buttonBox->button(QDialogButtonBox::Apply),
+            &QPushButton::clicked,
+            this,
+            &QEditorSettings::saveChanges);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QEditorSettings::cancel);
 }

--- a/QCodeEditor/src/QPythonEditor.cpp
+++ b/QCodeEditor/src/QPythonEditor.cpp
@@ -17,6 +17,7 @@
 
 #include "QPythonEditor.h"
 #include "CodeEditor.h"
+#include "PythonHighlighterSettings.h"
 #include "PythonInterpreter.h"
 
 // qCC
@@ -341,7 +342,6 @@ void QPythonEditor::indentLess()
     }
 }
 
-
 void QPythonEditor::executionStarted()
 {
     actionRun->setEnabled(false);
@@ -366,7 +366,7 @@ void QPythonEditor::createActions()
     connect(actionSaveAs, &QAction::triggered, this, &QPythonEditor::saveAs);
     connect(actionRun, &QAction::triggered, this, &QPythonEditor::runExecute);
     connect(actionClose, &QAction::triggered, this, [=]() { close(); });
-    connect(actionSettings, &QAction::triggered, this, [this]() { this->settings->show(); });
+    connect(actionSettings, &QAction::triggered, settings, &QEditorSettings::show);
 
     menuFile->addSeparator();
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${PROJECT_NAME}
         ${CMAKE_CURRENT_LIST_DIR}/PythonInterpreter.h
         ${CMAKE_CURRENT_LIST_DIR}/QPythonRepl.h
         ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighter.h
+        ${CMAKE_CURRENT_LIST_DIR}/ColorScheme.h
+        ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighterSettings.h
         ${CMAKE_CURRENT_LIST_DIR}/Consoles.h
         ${CMAKE_CURRENT_LIST_DIR}/ccGuiPythonInstance.h
         ${CMAKE_CURRENT_LIST_DIR}/FileRunner.h

--- a/include/ColorScheme.h
+++ b/include/ColorScheme.h
@@ -1,0 +1,41 @@
+#ifndef PYTHON_PLUGIN_COLOR_SCHEME_H
+#define PYTHON_PLUGIN_COLOR_SCHEME_H
+
+
+#include "PythonHighlighter.h"
+
+
+class ColorScheme final
+{
+  public:
+    using Vector = std::vector<ColorScheme>;
+
+    static const Vector &AvailableColorSchemes();
+    static const ColorScheme *ColorSchemeByName(const QString &name);
+
+    static ColorScheme Default();
+    static ColorScheme Dracula();
+
+    const QString &name() const;
+    QColor backgroundColor() const;
+    QColor foregroundColor() const;
+    QColor currentLineHighlightColor() const;
+
+    const QTextCharFormat &operator[](PythonHighlighter::CodeElement e) const;
+
+  private:
+    ColorScheme(QString name,
+                QVector<QTextCharFormat> &&formats,
+                const QTextFormat &defaultFormat,
+                QColor backgroundColor,
+                QColor currentLineHighlightColor);
+
+  private:
+    QString m_name;
+    QVector<QTextCharFormat> m_formats;
+    QTextFormat m_defaultFormat;
+    QColor m_backgroundColor;
+    QColor m_currentLineHighlightColor;
+};
+
+#endif

--- a/include/PythonHighlighter.h
+++ b/include/PythonHighlighter.h
@@ -30,9 +30,6 @@ class PythonHighlighter : public QSyntaxHighlighter
   public:
     explicit PythonHighlighter(QTextDocument *parent = nullptr);
 
-    // Helper
-    static QTextCharFormat format(const QString &colorName, const QString &style = QString());
-
   protected:
     void highlightBlock(const QString &text) override;
 

--- a/include/PythonHighlighter.h
+++ b/include/PythonHighlighter.h
@@ -15,9 +15,12 @@
 //#                                                                        #
 //##########################################################################
 
-// https://forum.qt.io/topic/96285/c-highlighter-for-python
-#ifndef PYTHONHIGHLIGHTER_H
-#define PYTHONHIGHLIGHTER_H
+// Original Author: "JeroenDierckx"
+// from https://forum.qt.io/topic/96285/c-highlighter-for-python
+// "The license is "don't make money off this without giving back to the community" ;-)"
+
+#ifndef PYTHON_HIGHLIGHTER_H
+#define PYTHON_HIGHLIGHTER_H
 
 #include <QRegExp>
 #include <QSyntaxHighlighter>
@@ -59,8 +62,9 @@ class PythonHighlighter : public QSyntaxHighlighter
 
     bool matchMultiLine(const QString &text, const HighlightingRule &rule);
 
-    QVector<HighlightingRule> _pythonHighlightingRules;
-    HighlightingRule _triSingle, _triDouble;
+    QVector<HighlightingRule> pythonHighlightingRules;
+    HighlightingRule triSingle;
+    HighlightingRule triDouble;
 };
 
-#endif // PYTHONHIGHLIGHTER_H
+#endif // PYTHON_HIGHLIGHTER_H

--- a/include/PythonHighlighter.h
+++ b/include/PythonHighlighter.h
@@ -22,15 +22,35 @@
 #ifndef PYTHON_HIGHLIGHTER_H
 #define PYTHON_HIGHLIGHTER_H
 
-#include <QRegExp>
 #include <QSyntaxHighlighter>
-#include <utility>
+
+
+class ColorScheme;
 
 // Started from Qt Syntax Highlighter example and then ported
 // https://wiki.python.org/moin/PyQt/Python%20syntax%20highlighting
 class PythonHighlighter : public QSyntaxHighlighter
 {
   public:
+    // For lack of a better name
+    enum class CodeElement
+    {
+        Keyword = 0,
+        Operator,
+        Brace,
+        Definition,
+        String,
+        DocString,
+        Comment,
+        Self,
+        Numbers,
+        End
+    };
+
+    static QString CodeElementName(PythonHighlighter::CodeElement e);
+
+	void useColorScheme(const ColorScheme &colorScheme);
+
     explicit PythonHighlighter(QTextDocument *parent = nullptr);
 
   protected:
@@ -39,19 +59,15 @@ class PythonHighlighter : public QSyntaxHighlighter
   private:
     struct HighlightingRule
     {
+        CodeElement element = CodeElement::End;
         QRegExp pattern;
         QTextCharFormat format;
         int matchIndex = 0;
-
+    	
         HighlightingRule() = default;
-
-        HighlightingRule(const QRegExp &r, int i, QTextCharFormat f)
-            : pattern(r), format(std::move(f)), matchIndex(i)
-        {
-        }
-
-        HighlightingRule(const QString &p, int i, QTextCharFormat f)
-            : pattern(QRegExp(p)), format(std::move(f)), matchIndex(i)
+    	
+        HighlightingRule(CodeElement e, const QString &p, int i)
+            : element(e), pattern(QRegExp(p)), matchIndex(i)
         {
         }
     };
@@ -66,5 +82,6 @@ class PythonHighlighter : public QSyntaxHighlighter
     HighlightingRule triSingle;
     HighlightingRule triDouble;
 };
+
 
 #endif // PYTHON_HIGHLIGHTER_H

--- a/include/PythonHighlighterSettings.h
+++ b/include/PythonHighlighterSettings.h
@@ -15,39 +15,27 @@
 //#                                                                        #
 //##########################################################################
 
-#ifndef PYTHON_PLUGIN_QEDITOR_SETTINGS_H
-#define PYTHON_PLUGIN_QEDITOR_SETTINGS_H
+#ifndef PYTHON_HIGHLIGHTER_SETTINGS_H
+#define PYTHON_HIGHLIGHTER_SETTINGS_H
 
-#include <ui_QEditorSettings.h>
+#include <QDialog>
+#include <QVector>
 
-#include "ColorScheme.h"
+#include "PythonHighlighter.h"
 
-class QEditorSettings final : public QDialog, public Ui::QEditorSettings
+class QColorDialog;
+class QSignalMapper;
+
+class PythonHighlighterSettings final : public QWidget
 {
     Q_OBJECT
   public:
-    QEditorSettings();
-
-    int fontSize() const;
-    bool shouldHighlightCurrentLine() const;
-    const ColorScheme &colorScheme() const;
-
-  public:
-  Q_SIGNALS:
-    void settingsChanged();
-
-  protected:
-    void connectSignals() const;
-    void saveChanges();
-    void saveChangesAndClose();
-    void cancel();
-    void setFormValuesToCurrentValues() const;
-    void loadFromSettings();
-    void setupUi();
+    explicit PythonHighlighterSettings(QWidget *parent = nullptr);
 
   private:
-    ColorScheme m_colorScheme = ColorScheme::Default();
-    bool m_shouldHighlightCurrentLine = true;
+    QColorDialog *colorDialog;
+    QSignalMapper *signalMapper;
+    QVector<QPair<PythonHighlighter::CodeElement, QColor>> colors;
 };
 
-#endif // PYTHON_PLUGIN_QEDITOR_SETTINGS_H
+#endif // PYTHON_HIGHLIGHTER_SETTINGS_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,9 @@ target_sources(${PROJECT_NAME}
         ${CMAKE_CURRENT_LIST_DIR}/PythonPlugin.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PythonInterpreter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/QPythonRepl.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighterSettings.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PythonHighlighter.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/ColorScheme.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ccGuiPythonInstance.cpp
         ${CMAKE_CURRENT_LIST_DIR}/FileRunner.cpp
         )

--- a/src/ColorScheme.cpp
+++ b/src/ColorScheme.cpp
@@ -1,0 +1,117 @@
+#include "ColorScheme.h"
+
+static QTextCharFormat FormatHelper(const QColor &color,
+                                    const QFont::Style style = QFont::Style::StyleNormal,
+                                    const QFont::Weight weight = QFont::Weight::Normal)
+{
+    QTextCharFormat charFormat;
+
+    charFormat.setForeground(color);
+    charFormat.setFontWeight(weight);
+    if (style == QFont::Style::StyleItalic)
+    {
+        charFormat.setFontItalic(true);
+    }
+
+    return charFormat;
+}
+
+static QTextCharFormat FormatHelper(const QColor &color, QFont::Weight weight)
+{
+    return FormatHelper(color, QFont::Style::StyleNormal, weight);
+}
+
+ColorScheme::ColorScheme(QString name,
+                         QVector<QTextCharFormat> &&formats,
+                         const QTextFormat &defaultFormat,
+                         QColor backgroundColor,
+                         QColor currentLineHighlightColor)
+    : m_name(name), m_formats(formats), m_defaultFormat(defaultFormat), m_backgroundColor(std::move(backgroundColor)),
+      m_currentLineHighlightColor(std::move(currentLineHighlightColor))
+{
+    Q_ASSERT(formats.size() == static_cast<int>(PythonHighlighter::CodeElement::End));
+}
+
+QColor ColorScheme::foregroundColor() const
+{
+    return m_defaultFormat.foreground().color();
+}
+
+QColor ColorScheme::backgroundColor() const
+{
+    return m_backgroundColor;
+}
+
+QColor ColorScheme::currentLineHighlightColor() const
+{
+    return m_currentLineHighlightColor;
+}
+
+const QTextCharFormat &ColorScheme::operator[](PythonHighlighter::CodeElement e) const
+{
+    const auto index = static_cast<int>(e);
+    Q_ASSERT(index < m_formats.size());
+    return m_formats[index];
+}
+
+ColorScheme ColorScheme::Default()
+{
+    QVector<QTextCharFormat> formats{FormatHelper(Qt::blue),
+                                     FormatHelper(Qt::red),
+                                     FormatHelper(Qt::darkGray),
+                                     FormatHelper(Qt::black, QFont::Bold),
+                                     FormatHelper(Qt::magenta),
+                                     FormatHelper(Qt::darkMagenta, QFont::StyleItalic),
+                                     FormatHelper(Qt::darkGreen, QFont::StyleItalic),
+                                     FormatHelper(Qt::black, QFont::StyleItalic),
+                                     FormatHelper("brown")};
+
+    return
+    {
+        "Default", std::move(formats), FormatHelper(Qt::black), Qt::white, QColor(Qt::yellow).lighter(160)
+    };
+};
+
+ColorScheme ColorScheme::Dracula()
+{
+    QVector<QTextCharFormat> formats{FormatHelper(QColor(255, 121, 198)),
+                                     FormatHelper(Qt::red),
+                                     FormatHelper(Qt::darkGray),
+                                     FormatHelper(QColor(80, 250, 123), QFont::Bold),
+                                     FormatHelper(QColor(241, 250, 140)),
+                                     FormatHelper(Qt::darkMagenta, QFont::StyleItalic),
+                                     FormatHelper(QColor(98, 114, 164), QFont::StyleItalic),
+                                     FormatHelper(QColor(255, 184, 108), QFont::StyleItalic),
+                                     FormatHelper("brown")};
+
+    return {"Dracula", std::move(formats), FormatHelper(QColor(248, 248, 242)), QColor(40, 42, 54), QColor(68, 71, 90)};
+}
+
+const QString& ColorScheme::name() const
+{
+    return m_name;
+};
+static ColorScheme::Vector s_AvailableColorSchemes;
+
+const ColorScheme::Vector &ColorScheme::AvailableColorSchemes()
+{
+    if (s_AvailableColorSchemes.empty())
+    {
+        s_AvailableColorSchemes.push_back(ColorScheme::Default());
+        s_AvailableColorSchemes.push_back(ColorScheme::Dracula());
+    }
+    return s_AvailableColorSchemes;
+}
+
+const ColorScheme *ColorScheme::ColorSchemeByName(const QString &name)
+{
+    const auto it = std::find_if(s_AvailableColorSchemes.begin(),
+              s_AvailableColorSchemes.end(),
+              [name](const ColorScheme &colorScheme) { return colorScheme.name() == name; });
+
+    if (it != s_AvailableColorSchemes.end())
+    {
+        return &*it;
+    }
+    return nullptr;
+}

--- a/src/PythonHighlighter.cpp
+++ b/src/PythonHighlighter.cpp
@@ -118,48 +118,48 @@ void PythonHighlighter::initialize()
     // Multi-line strings (expression, flag, style)
     // FIXME: The triple-quotes in these two lines will mess up the
     // syntax highlighting from this point onward
-    _triSingle = HighlightingRule("'''", 1, s_Styles[CodeElement::DocString]);
-    _triDouble = HighlightingRule(R"(""")", 2, s_Styles[CodeElement::DocString]);
+    triSingle = HighlightingRule("'''", 1, s_Styles[CodeElement::DocString]);
+    triDouble = HighlightingRule(R"(""")", 2, s_Styles[CodeElement::DocString]);
 
     // Keyword, operator, and brace rules
     for (const QString &keyword : s_Keywords)
     {
         QString pattern = QString("\\b%1\\b").arg(keyword);
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Keyword]);
+        pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Keyword]);
     }
 
     for (const QString &pattern : s_Operators)
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Operator]);
+        pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Operator]);
 
     for (const QString &pattern : s_Braces)
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Brace]);
+        pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Brace]);
 
     // All other rules
 
     // 'self'
-    _pythonHighlightingRules += HighlightingRule("\\bself\\b", 0, s_Styles[CodeElement::Self]);
+    pythonHighlightingRules += HighlightingRule("\\bself\\b", 0, s_Styles[CodeElement::Self]);
 
     // Double-quoted string, possibly containing escape sequences
-    _pythonHighlightingRules +=
+    pythonHighlightingRules +=
         HighlightingRule(R"("[^"\\]*(\\.[^"\\]*)*")", 0, s_Styles[CodeElement::String]);
     // Single-quoted string, possibly containing escape sequences
-    _pythonHighlightingRules +=
+    pythonHighlightingRules +=
         HighlightingRule(R"("[^'\\]*(\\.[^'\\]*)*")", 0, s_Styles[CodeElement::String]);
 
     // 'def' followed by an identifier
-    _pythonHighlightingRules += HighlightingRule(R"(\bdef\b\s*(\w+))", 1, s_Styles[CodeElement::Definition]);
+    pythonHighlightingRules += HighlightingRule(R"(\bdef\b\s*(\w+))", 1, s_Styles[CodeElement::Definition]);
     // 'class' followed by an identifier
-    _pythonHighlightingRules +=
+    pythonHighlightingRules +=
         HighlightingRule(R"(\bclass\b\s*(\w+))", 1, s_Styles[CodeElement::Definition]);
 
     // From '#' until a newline
-    _pythonHighlightingRules += HighlightingRule("#[^\\n]*", 0, s_Styles[CodeElement::Comment]);
+    pythonHighlightingRules += HighlightingRule("#[^\\n]*", 0, s_Styles[CodeElement::Comment]);
 
     // Numeric literals
-    _pythonHighlightingRules += HighlightingRule("\\b[+-]?[0-9]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
-    _pythonHighlightingRules +=
+    pythonHighlightingRules += HighlightingRule("\\b[+-]?[0-9]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
+    pythonHighlightingRules +=
         HighlightingRule("\\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
-    _pythonHighlightingRules += HighlightingRule(
+    pythonHighlightingRules += HighlightingRule(
         R"(\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b)", 0, s_Styles[CodeElement::Numbers]);
 }
 
@@ -171,7 +171,7 @@ void PythonHighlighter::highlightPythonBlock(const QString &text)
     int index = -1;
 
     // Do other syntax formatting
-    for (const auto &rule : _pythonHighlightingRules)
+    for (const auto &rule : pythonHighlightingRules)
     {
         index = rule.pattern.indexIn(text, 0);
 
@@ -191,9 +191,9 @@ void PythonHighlighter::highlightPythonBlock(const QString &text)
     setCurrentBlockState(0);
 
     // Do multi-line strings
-    bool in_multiline = matchMultiLine(text, _triSingle);
+    bool in_multiline = matchMultiLine(text, triSingle);
     if (!in_multiline)
-        in_multiline = matchMultiLine(text, _triDouble);
+        in_multiline = matchMultiLine(text, triDouble);
 }
 
 /*Do highlighting of multi-line strings. ``delimiter`` should be a

--- a/src/PythonHighlighter.cpp
+++ b/src/PythonHighlighter.cpp
@@ -147,10 +147,10 @@ void PythonHighlighter::initialize()
         HighlightingRule(R"("[^'\\]*(\\.[^'\\]*)*")", 0, s_Styles[CodeElement::String]);
 
     // 'def' followed by an identifier
-    _pythonHighlightingRules += HighlightingRule("\\bdef\\b\\s*(\\w+)", 1, s_Styles[CodeElement::Definition]);
+    _pythonHighlightingRules += HighlightingRule(R"(\bdef\b\s*(\w+))", 1, s_Styles[CodeElement::Definition]);
     // 'class' followed by an identifier
     _pythonHighlightingRules +=
-        HighlightingRule("\\bclass\\b\\s*(\\w+)", 1, s_Styles[CodeElement::Definition]);
+        HighlightingRule(R"(\bclass\b\s*(\w+))", 1, s_Styles[CodeElement::Definition]);
 
     // From '#' until a newline
     _pythonHighlightingRules += HighlightingRule("#[^\\n]*", 0, s_Styles[CodeElement::Comment]);
@@ -160,7 +160,7 @@ void PythonHighlighter::initialize()
     _pythonHighlightingRules +=
         HighlightingRule("\\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
     _pythonHighlightingRules += HighlightingRule(
-        "\\b[+-]?[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\\b", 0, s_Styles[CodeElement::Numbers]);
+        R"(\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b)", 0, s_Styles[CodeElement::Numbers]);
 }
 
 void PythonHighlighter::highlightPythonBlock(const QString &text)
@@ -246,8 +246,5 @@ bool PythonHighlighter::matchMultiLine(const QString &text, const HighlightingRu
     }
 
     // Return True if still inside a multi-line string, False otherwise
-    if (currentBlockState() == rule.matchIndex)
-        return true;
-    else
-        return false;
+    return currentBlockState() == rule.matchIndex;
 }

--- a/src/PythonHighlighter.cpp
+++ b/src/PythonHighlighter.cpp
@@ -17,112 +17,150 @@
 
 #include "PythonHighlighter.h"
 
+static QTextCharFormat FormatHelper(const QColor &color,
+                                    QFont::Style style = QFont::Style::StyleNormal,
+                                    QFont::Weight weight = QFont::Weight::Normal)
+{
+    QTextCharFormat charFormat;
 
-// Syntax styles that can be shared by all languages
-typedef QMap<QString, QTextCharFormat> FormatMap;
-// static FormatMap STYLES;
-static const FormatMap STYLES = {{"keyword", PythonHighlighter::format("blue")},
-                                 {"operator", PythonHighlighter::format("red")},
-                                 {"brace", PythonHighlighter::format("darkGray")},
-                                 {"defclass", PythonHighlighter::format("black", "bold")},
-                                 {"string", PythonHighlighter::format("magenta")},
-                                 {"string2", PythonHighlighter::format("darkMagenta")},
-                                 {"comment", PythonHighlighter::format("darkGreen", "italic")},
-                                 {"self", PythonHighlighter::format("black", "italic")},
-                                 {"numbers", PythonHighlighter::format("brown")}};
+    charFormat.setForeground(color);
+    charFormat.setFontWeight(weight);
+    if (style == QFont::Style::StyleItalic)
+    {
+        charFormat.setFontItalic(true);
+    }
+
+    return charFormat;
+}
+
+static QTextCharFormat FormatHelper(const QColor &color, QFont::Weight weight)
+{
+    return FormatHelper(color, QFont::Style::StyleNormal, weight);
+}
+
+// For lack of a better name
+enum class CodeElement
+{
+    Keyword = 0,
+    Operator,
+    Brace,
+    Definition,
+    String,
+    DocString,
+    Comment,
+    Self,
+    Numbers
+};
+
+static const QMap<CodeElement, QTextCharFormat> s_Styles = {
+    {CodeElement::Keyword, FormatHelper(Qt::blue)},
+    {CodeElement::Operator, FormatHelper(Qt::red)},
+    {CodeElement::Brace, FormatHelper(Qt::darkGray)},
+    {CodeElement::Definition, FormatHelper(Qt::black, QFont::Bold)},
+    {CodeElement::String, FormatHelper(Qt::magenta)},
+    {CodeElement::DocString, FormatHelper(Qt::darkMagenta, QFont::StyleItalic)},
+    {CodeElement::Comment, FormatHelper(Qt::darkGreen, QFont::StyleItalic)},
+    {CodeElement::Self, FormatHelper(Qt::black, QFont::StyleItalic)},
+    {CodeElement::Numbers, FormatHelper("brown")}};
 
 // Python keywords
-static const QStringList keywords = {
+static const QStringList s_Keywords = {
     "and",     "assert", "break", "class",  "continue", "def",    "del",   "elif", "else",   "except", "exec",
     "finally", "for",    "from",  "global", "if",       "import", "in",    "is",   "lambda", "not",    "or",
     "pass",    "print",  "raise", "return", "try",      "while",  "yield", "None", "True",   "False"};
 
 // Python operators
-static const QStringList operators = {"=",
-                                      // Comparison
-                                      "==",
-                                      "!=",
-                                      "<",
-                                      "<=",
-                                      ">",
-                                      ">=",
-                                      // Arithmetic
-                                      "\\+",
-                                      "-",
-                                      "\\*",
-                                      "/",
-                                      "//",
-                                      "\\%",
-                                      "\\*\\*",
-                                      // In-place
-                                      "\\+=",
-                                      "-=",
-                                      "\\*=",
-                                      "/=",
-                                      "\\%=",
-                                      // Bitwise
-                                      "\\^",
-                                      "\\|",
-                                      "\\&",
-                                      "\\~",
-                                      ">>",
-                                      "<<"};
+static const QStringList s_Operators = {"=",
+                                        // Comparison
+                                        "==",
+                                        "!=",
+                                        "<",
+                                        "<=",
+                                        ">",
+                                        ">=",
+                                        // Arithmetic
+                                        "\\+",
+                                        "-",
+                                        "\\*",
+                                        "/",
+                                        "//",
+                                        "\\%",
+                                        "\\*\\*",
+                                        // In-place
+                                        "\\+=",
+                                        "-=",
+                                        "\\*=",
+                                        "/=",
+                                        "\\%=",
+                                        // Bitwise
+                                        "\\^",
+                                        "\\|",
+                                        "\\&",
+                                        "\\~",
+                                        ">>",
+                                        "<<"};
 
 // Python braces
-static const QStringList braces = {"\\{", "\\}", "\\(", "\\)", R"([)", R"(])"};
+static const QStringList s_Braces = {"\\{", "\\}", "\\(", "\\)", R"([)", R"(])"};
 
-/////
+PythonHighlighter::PythonHighlighter(QTextDocument *parent) : QSyntaxHighlighter(parent)
+{
+    initialize();
+}
 
-PythonHighlighter::PythonHighlighter(QTextDocument *parent) : QSyntaxHighlighter(parent) { initialize(); }
-
-void PythonHighlighter::highlightBlock(const QString &text) { highlightPythonBlock(text); }
-
-/////
+void PythonHighlighter::highlightBlock(const QString &text)
+{
+    highlightPythonBlock(text);
+}
 
 void PythonHighlighter::initialize()
 {
     // Multi-line strings (expression, flag, style)
     // FIXME: The triple-quotes in these two lines will mess up the
     // syntax highlighting from this point onward
-    _triSingle = HighlightingRule("'''", 1, STYLES["string2"]);
-    _triDouble = HighlightingRule(R"(""")", 2, STYLES["string2"]);
+    _triSingle = HighlightingRule("'''", 1, s_Styles[CodeElement::DocString]);
+    _triDouble = HighlightingRule(R"(""")", 2, s_Styles[CodeElement::DocString]);
 
     // Keyword, operator, and brace rules
-    for (const QString &keyword : keywords)
+    for (const QString &keyword : s_Keywords)
     {
         QString pattern = QString("\\b%1\\b").arg(keyword);
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, STYLES["keyword"]);
+        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Keyword]);
     }
 
-    for (const QString &pattern : operators)
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, STYLES["operator"]);
+    for (const QString &pattern : s_Operators)
+        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Operator]);
 
-    for (const QString &pattern : braces)
-        _pythonHighlightingRules += HighlightingRule(pattern, 0, STYLES["brace"]);
+    for (const QString &pattern : s_Braces)
+        _pythonHighlightingRules += HighlightingRule(pattern, 0, s_Styles[CodeElement::Brace]);
 
     // All other rules
 
     // 'self'
-    _pythonHighlightingRules += HighlightingRule("\\bself\\b", 0, STYLES["self"]);
+    _pythonHighlightingRules += HighlightingRule("\\bself\\b", 0, s_Styles[CodeElement::Self]);
 
     // Double-quoted string, possibly containing escape sequences
-    _pythonHighlightingRules += HighlightingRule(R"("[^"\\]*(\\.[^"\\]*)*")", 0, STYLES["string"]);
+    _pythonHighlightingRules +=
+        HighlightingRule(R"("[^"\\]*(\\.[^"\\]*)*")", 0, s_Styles[CodeElement::String]);
     // Single-quoted string, possibly containing escape sequences
-    _pythonHighlightingRules += HighlightingRule(R"("[^'\\]*(\\.[^'\\]*)*")", 0, STYLES["string"]);
+    _pythonHighlightingRules +=
+        HighlightingRule(R"("[^'\\]*(\\.[^'\\]*)*")", 0, s_Styles[CodeElement::String]);
 
     // 'def' followed by an identifier
-    _pythonHighlightingRules += HighlightingRule("\\bdef\\b\\s*(\\w+)", 1, STYLES["defclass"]);
+    _pythonHighlightingRules += HighlightingRule("\\bdef\\b\\s*(\\w+)", 1, s_Styles[CodeElement::Definition]);
     // 'class' followed by an identifier
-    _pythonHighlightingRules += HighlightingRule("\\bclass\\b\\s*(\\w+)", 1, STYLES["defclass"]);
+    _pythonHighlightingRules +=
+        HighlightingRule("\\bclass\\b\\s*(\\w+)", 1, s_Styles[CodeElement::Definition]);
 
     // From '#' until a newline
-    _pythonHighlightingRules += HighlightingRule("#[^\\n]*", 0, STYLES["comment"]);
+    _pythonHighlightingRules += HighlightingRule("#[^\\n]*", 0, s_Styles[CodeElement::Comment]);
 
     // Numeric literals
-    _pythonHighlightingRules += HighlightingRule("\\b[+-]?[0-9]+[lL]?\\b", 0, STYLES["numbers"]);
-    _pythonHighlightingRules += HighlightingRule("\\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\\b", 0, STYLES["numbers"]);
+    _pythonHighlightingRules += HighlightingRule("\\b[+-]?[0-9]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
     _pythonHighlightingRules +=
-        HighlightingRule("\\b[+-]?[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\\b", 0, STYLES["numbers"]);
+        HighlightingRule("\\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\\b", 0, s_Styles[CodeElement::Numbers]);
+    _pythonHighlightingRules += HighlightingRule(
+        "\\b[+-]?[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\\b", 0, s_Styles[CodeElement::Numbers]);
 }
 
 void PythonHighlighter::highlightPythonBlock(const QString &text)
@@ -156,23 +194,6 @@ void PythonHighlighter::highlightPythonBlock(const QString &text)
     bool in_multiline = matchMultiLine(text, _triSingle);
     if (!in_multiline)
         in_multiline = matchMultiLine(text, _triDouble);
-}
-
-// Return a QTextCharFormat with the given attributes.
-QTextCharFormat PythonHighlighter::format(const QString &colorName, const QString &style)
-{
-    QColor color;
-    color.setNamedColor(colorName);
-
-    QTextCharFormat format;
-    format.setForeground(color);
-
-    if (style.contains("bold"))
-        format.setFontWeight(QFont::Bold);
-    if (style.contains("italic"))
-        format.setFontItalic(true);
-
-    return format;
 }
 
 /*Do highlighting of multi-line strings. ``delimiter`` should be a

--- a/src/PythonHighlighterSettings.cpp
+++ b/src/PythonHighlighterSettings.cpp
@@ -1,0 +1,54 @@
+//##########################################################################
+//#                                                                        #
+//#              CLOUDCOMPARE PLUGIN: PythonPlugin                         #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: Thomas Montaigu                                    #
+//#                                                                        #
+//##########################################################################
+
+#include "PythonHighlighterSettings.h"
+
+#include "PythonHighlighter.h"
+
+
+#include <QColorDialog>
+#include <QFormLayout>
+#include <QPushButton>
+#include <QSignalMapper>
+
+PythonHighlighterSettings::PythonHighlighterSettings(QWidget *parent)
+    : QWidget(parent)
+    , colorDialog(new QColorDialog(this))
+    , signalMapper(new QSignalMapper(this)) {
+    auto formLayout = new QFormLayout;
+    setLayout(formLayout);
+
+    const int numCodeElement = static_cast<size_t>(PythonHighlighter::CodeElement::End);
+    colors.resize(numCodeElement);
+    for (int i{0}; i < numCodeElement; ++i)
+    {
+        const auto e = static_cast<PythonHighlighter::CodeElement>(i);
+        auto *btn = new QPushButton;
+        const auto qss = QString("background-color: red");
+        btn->setStyleSheet(qss);
+        formLayout->addRow(PythonHighlighter::CodeElementName(e), btn);
+       
+        connect(btn, &QPushButton::clicked, [this, btn, i]
+        {
+            colorDialog->exec();
+            colors[i].second = colorDialog->selectedColor();
+            btn->setStyleSheet(QString("background-color: %1")
+                .arg(colors[i].second.name(QColor::HexRgb)));
+        });
+    }
+}
+

--- a/ui/QEditorSettings.ui
+++ b/ui/QEditorSettings.ui
@@ -1,35 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>QEditorSettings</class>
- <widget class="QWidget" name="QEditorSettings">
+ <widget class="QDialog" name="QEditorSettings">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>474</width>
-    <height>417</height>
+    <width>270</width>
+    <height>149</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Editor Settings</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Font Size</string>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+      </property>
+      <property name="labelAlignment">
+       <set>Qt::AlignHCenter|Qt::AlignTop</set>
+      </property>
+      <property name="formAlignment">
+       <set>Qt::AlignHCenter|Qt::AlignTop</set>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Font Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="fontSizeSpinBox">
+        <property name="value">
+         <number>14</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="colorSchemeLabel">
+        <property name="text">
+         <string>Color Scheme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="colorSchemeComboBox"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="highlightCurrentLineCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Highlight current line</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QSpinBox" name="fontSizeSpinBox">
-     <property name="value">
-      <number>14</number>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
-   </item>
-   <item row="2" column="1">
-    <layout class="QFormLayout" name="formLayout_2"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This makes the settings menu of the Editor nicer, and now it also have actual options

The more important one is a color scheme option, where we can now
chose between 2 color schemes (Default and Dracula)

 - Add color scheme selection to editor settings
 - Add checkbox to tell whether the current line should be highlighted
 - Use QSettings to persistently save settings