### PR TITLE
macos build

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        use_embedded_modules: [ON, OFF]
+        use_embedded_modules: [ ON, OFF ]
 
     steps:
       - name: Clone CloudCompare
@@ -74,7 +74,7 @@ jobs:
           pytest --cloudcompare_exe ${{ github.workspace }}/install/CloudCompare/CloudCompare.exe tests
 
   Ubuntu-Build:
-    name: Ubuntu
+    name: "Ubuntu Build"
     runs-on: ubuntu-latest
 
     steps:
@@ -118,6 +118,54 @@ jobs:
           cd plugins/private/CloudCompare-PythonPlugin
           export LD_LIBRARY_PATH=/usr/local/lib
           xvfb-run python3 -m pytest --cloudcompare_exe /usr/local/bin/CloudCompare tests
+
+  MacOs-Build:
+    name: "macOs Build"
+    runs-on: macos-latest
+    if: false
+
+    steps:
+      - name: Clone CloudCompare
+        uses: actions/checkout@v2
+        with:
+          repository: 'CloudCompare/CloudCompare'
+          ref: '2a92607384aba4d35f29e733477ab733f571cfe2'
+          submodules: true
+
+      - name: Clone PythonPlugin
+        uses: actions/checkout@v2
+        with:
+          path: 'plugins/private/CloudCompare-PythonPlugin'
+
+      - name: Install Dependencies
+        run: |
+          brew install qt@5 ninja pybind11
+          python3 -m pip install pytest
+          echo "CMAKE_PREFIX_PATH=/usr/local/opt/qt@5" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        shell: pwsh
+        run: |
+          mkdir build
+          cmake  `
+            -G Ninja `
+            -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_INSTALL_PREFIX=install `
+            -DPLUGIN_PYTHON=ON `
+            .
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Install
+        run: sudo cmake --install build
+
+      - name: Run Tests
+        run: |
+          python3 -m pip install pytest
+          cd plugins/private/CloudCompare-PythonPlugin
+          python3 -m pytest --cloudcompare_exe ${{ github.workspace }}/install/bin/CloudCompare tests
 
 
   Windows-Wheels:
@@ -187,8 +235,36 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -v --use-feature=in-tree-build ./pycc
 
-      - name: test cccorelib & cccorelib
+      - name: test cccorelib & pycc
         run: |
           python3 -m pytest wrapper/cccorelib/tests
           python3 -m pytest wrapper/pycc/tests
 
+
+  MacOs-Wheels:
+    name: "macOs Wheels"
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: |
+          brew install qt@5 ninja
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pytest
+          echo "CMAKE_PREFIX_PATH=/usr/local/opt/qt@5" >> $GITHUB_ENV
+
+      - name: pip install cccorelib
+        working-directory: "./wrapper"
+        run: python3 -m pip install -v ./cccorelib
+
+      - name: pip install pycc
+        working-directory: "./wrapper"
+        run: |
+          python3 -m pip install -v --use-feature=in-tree-build ./pycc
+
+      - name: test cccorelib & pycc
+        run: |
+          python3 -m pytest wrapper/cccorelib/tests
+          python3 -m pytest wrapper/pycc/tests


### PR DESCRIPTION
- Can't install when building as plugin as the CloudCompare macOs install seems broken
- Can only build & test cccorelib when build as python package (still due to CloudComapre macOs install not working)