### PR TITLE
Python list script implemented to accelerate and facilitate the launc…

### DIFF
--- a/src/PythonPlugin.h
+++ b/src/PythonPlugin.h
@@ -23,6 +23,10 @@
 #include "PythonPluginManager.h"
 #include "ccStdPluginInterface.h"
 
+#include <map>
+#include <vector>
+#include <iostream>
+
 class QListWidget;
 class PythonEditor;
 class PythonRepl;
@@ -50,6 +54,8 @@ class PythonPlugin final : public QObject, public ccStdPluginInterface
 
     void setMainAppInterface(ccMainAppInterface *app) override;
 
+    void stop() override;
+
     PythonPlugin(const PythonPlugin &) = delete;
     PythonPlugin(PythonPlugin &&) = delete;
     PythonPlugin &operator=(const PythonPlugin &) = delete;
@@ -66,6 +72,12 @@ class PythonPlugin final : public QObject, public ccStdPluginInterface
     void showPythonActionLauncher() const;
     void showSettings() const;
     static void showDocumentation();
+
+    //Script list function
+    void addScriptAction();
+    void addScript(QString path);
+    void executeScript(QString path);
+    void removeScript(QString name, QAction* self);
 
     PythonConfig m_config{};
     PythonInterpreter m_interp;
@@ -87,6 +99,16 @@ class PythonPlugin final : public QObject, public ccStdPluginInterface
     QAction *m_showPackageManager{nullptr};
     QAction *m_showActionLauncher{nullptr};
     QAction *m_showSettings{nullptr};
+
+    /// Script list submenu
+    QMenu *m_drawScriptRegister{nullptr};
+
+    /// Variable for script list submenu
+    QAction *m_addScript{nullptr};
+    QMenu *m_removeScript{nullptr};
+    std::map<QString, QAction*> m_scriptList;
+    QStringList m_savedPath;
+    QString m_saveFilePath;
 };
 
 #endif // PYTHON_PLUGIN_H


### PR DESCRIPTION
Python script list implemented to save and launch easily python script:

![image](https://user-images.githubusercontent.com/98394907/161734192-b6fb5bd2-3355-4892-a5d9-e7b0c6fb0eb9.png)


Modifications on src/PythonPlugin.h:

- Add reference to sub-menu script register and its different interactive object.
- Add reference to list of every python script path and save file path.
- Add reference to script list function.

Modifications on src/PythonPlugin.cpp: 

- Modification of `getActions` to setup script register sub-menu and save file load/create.
- Implementation of `addScriptAction` and `addScript` to generate dynamically the execute button and the remove button stacked in the remove sub-menu.
- Implementation of `executeScript` to call the python interpreter with the selected file path.
- Implementation of `removeScript` to delete execute script action from the script register.