### PR TITLE
Add python3.dll to CC root directory on Windows (partial fix for #39)

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -37,6 +37,8 @@ function(copy_python_dll)
     "Python DLL: = ${PYTHON_BASE_PREFIX}/python${PYTHON_LIBRARY_SUFFIX}.dll"
   )
   install(FILES "${PYTHON_BASE_PREFIX}/python${PYTHON_LIBRARY_SUFFIX}.dll"
+                #install the python3 base dll as well because some libs will try to find it (PySide and PyQT for example)
+                "${PYTHON_BASE_PREFIX}/python3.dll" 
           DESTINATION ${CLOUDCOMPARE_DEST_FOLDER}
   )
 endfunction()

--- a/installer/Installer.wxs
+++ b/installer/Installer.wxs
@@ -51,9 +51,13 @@
 
         <!-- Files to put int our installer  -->
         <DirectoryRef Id="CLOUDCOMPAREDIR">
-            <Component Id='OfficialPythonDLL' Guid='fd589986-9e18-491c-9272-a2ead3a573b9' Win64="yes">
-                <File Id='PythonDll' Name='python$(var.PythonSuffix).dll' DiskId='1'
-                      Source='$(var.SourceInstallPath)/python$(var.PythonSuffix).dll' KeyPath='yes'/>
+            <Component Id='OfficialPythonDLLBase' Guid='fd589986-9e18-491c-9272-a2ead3a573b1' Win64="yes">
+                <File Id='PythonDllBase' Name='python3.dll' DiskId='1'
+                      Source='$(var.SourceInstallPath)/python3.dll' KeyPath='yes'/>
+           </Component>
+            <Component Id='OfficialPythonDLLMinor' Guid='fd589986-9e18-491c-9272-a2ead3a573b9' Win64="yes">
+                <File Id='PythonDllMinor' Name='python3$(var.PythonSuffix).dll' DiskId='1'
+                      Source='$(var.SourceInstallPath)/python3$(var.PythonSuffix).dll' KeyPath='yes'/>
             </Component>
         </DirectoryRef>
 
@@ -74,8 +78,8 @@
 
             <DirectoryRef Id='PYTHONPLUGINSDIR'>
                 <Component Id='QM3C2_PLUGIN_WRAPPER' Guid='22964a74-bcb4-4898-a3fd-be2b261d9e76' Win64="yes">
-                    <File Id='QM3C2_PLUGIN_WRAPPER_PYD' Name='pym3c2.cp$(var.PythonSuffix)-win_amd64.pyd' DiskId='1'
-                          Source='$(var.SourceInstallPath)/plugins-python/pym3c2.cp$(var.PythonSuffix)-win_amd64.pyd'
+                    <File Id='QM3C2_PLUGIN_WRAPPER_PYD' Name='pym3c2.cp3$(var.PythonSuffix)-win_amd64.pyd' DiskId='1'
+                          Source='$(var.SourceInstallPath)/plugins-python/pym3c2.cp3$(var.PythonSuffix)-win_amd64.pyd'
                           KeyPath='yes'/>
                 </Component>
             </DirectoryRef>
@@ -88,7 +92,8 @@
             <Feature Id='PythonPluginFeature' Level='1' Title='Python Plugin' Description='Python Plugin for CloudCompare'>
                 <ComponentRef Id='PythonPlugin'/>
                 <ComponentGroupRef Id='PythonEnvironment'/>
-                <ComponentRef Id='OfficialPythonDLL'/>
+                <ComponentRef Id='OfficialPythonDLLBase'/>
+                <ComponentRef Id='OfficialPythonDLLMinor'/>
             </Feature>
 
 


### PR DESCRIPTION
This is a partial fix for #39 (as anyway QT and compiler env used by PyQT/PySIde needs to match the ones used by CloudCompare).
In fact the issue was the same as the one described here for example: https://github.com/pypa/virtualenv/issues/1050. As consequence,  we need to ensure that python3.dll is present along with python3<minor version>.dll in CloudCompare root dir.

I tested this on Python310 and PySide2 (5.12.1)  and PyQT5  (5.12.9) both taken from PyPI against current CC alpha and it works like a charm.