### PR TITLE
Add missing ccHobject constructor

### DIFF
--- a/wrapper/pycc/src/qcc_db/ccObject.cpp
+++ b/wrapper/pycc/src/qcc_db/ccObject.cpp
@@ -115,6 +115,10 @@ void define_ccObject(py::module &m)
         .export_values();
 
     py::class_<ccHObject, ccObject, ccDrawableObject>(m, "ccHObject")
+        .def(
+            py::init<QString, unsigned>(),
+            "name"_a = QString(),
+            "uniqueID"_a = []() { return ccUniqueIDGenerator::InvalidUniqueID; }())
         .def("isGroup", &ccHObject::isGroup)
         .def("getParent", &ccHObject::getParent, py::return_value_policy::reference_internal)
         // Children management


### PR DESCRIPTION
Tiny change. ccHobject are convenient to create groups (="folders") in CloudCompare DbTree