### PR TITLE
Flatten menu hierarchy if the plugin provides only one Action

### DIFF
--- a/src/PythonPlugin.h
+++ b/src/PythonPlugin.h
@@ -110,6 +110,9 @@ class PythonPlugin final : public QObject, public ccStdPluginInterface
     QMenu *m_drawScriptRegister{nullptr};
     QMenu *m_pluginsMenu{nullptr};
 
+    /// keep track of plugins QAction and their corresponding registered plugin actions
+    std::map<const QAction *, const Runtime::RegisteredPlugin::Action *> m_pluginActions;
+
     /// Variable for script list submenu
     QAction *m_addScript{nullptr};
     QMenu *m_removeScript{nullptr};


### PR DESCRIPTION
proposal to handle menu hierarchy when the plugin embed only one action. This will result in a similar behavior than "regular" CC plugins.