### PR TITLE
Improve ccShiftedObject

### DIFF
--- a/wrapper/pycc/src/qcc_db/ccObject.cpp
+++ b/wrapper/pycc/src/qcc_db/ccObject.cpp
@@ -201,5 +201,5 @@ void define_ccObject(py::module &m)
         .def("getGlobalShift", &ccShiftedObject::getGlobalShift)
         .def("setGlobalScale", &ccShiftedObject::setGlobalScale, "scale"_a)
         .def("isShifted", &ccShiftedObject::isShifted)
-        .def("getGlobalScale", &ccShiftedObject::setGlobalScale);
+        .def("getGlobalScale", &ccShiftedObject::getGlobalScale);
 }

--- a/wrapper/pycc/src/qcc_db/ccObject.cpp
+++ b/wrapper/pycc/src/qcc_db/ccObject.cpp
@@ -201,5 +201,6 @@ void define_ccObject(py::module &m)
         .def("getGlobalShift", &ccShiftedObject::getGlobalShift)
         .def("setGlobalScale", &ccShiftedObject::setGlobalScale, "scale"_a)
         .def("isShifted", &ccShiftedObject::isShifted)
-        .def("getGlobalScale", &ccShiftedObject::getGlobalScale);
+        .def("getGlobalScale", &ccShiftedObject::getGlobalScale)
+        .def("copyGlobalShiftAndScale", &ccShiftedObject::copyGlobalShiftAndScale, "s"_a);
 }


### PR DESCRIPTION
- Fix a method definition
- Add the 'new'  `copyGlobalShiftAndScale` method (not so useful since it can be emulated by composition of exiting ones)