### PR TITLE
Add missing casters.h include

### DIFF
--- a/wrapper/pycc/src/qcc_db/ccGenericPrimitive.cpp
+++ b/wrapper/pycc/src/qcc_db/ccGenericPrimitive.cpp
@@ -23,6 +23,8 @@
 #include <ccGenericPrimitive.h>
 #include <ccMesh.h>
 
+#include "../casters.h"
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 


### PR DESCRIPTION
Without this include, methods of the translation unit do not know how to convert a QQString to a python str.