### PR TITLE
Added a missing argument of convertToCloud

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'CloudCompare/CloudCompare'
-          ref: 3eeee79f933dd7d5d1f79135f40bb38e12da1485
+          ref: d917d67e688eebfdd0d5dde6ce2dbe634ae1e531
           submodules: recursive
 
       - name: Clone PythonPlugin
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'CloudCompare/CloudCompare'
-          ref: 3eeee79f933dd7d5d1f79135f40bb38e12da1485
+          ref: d917d67e688eebfdd0d5dde6ce2dbe634ae1e531
           submodules: recursive
 
       - name: Clone PythonPlugin
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'CloudCompare/CloudCompare'
-          ref: 3eeee79f933dd7d5d1f79135f40bb38e12da1485
+          ref: d917d67e688eebfdd0d5dde6ce2dbe634ae1e531
           submodules: recursive
 
       - name: Clone PythonPlugin

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -32,7 +32,7 @@ to the CloudCompare documentation on how to do.
 To compile this plugin you need to have Python installed.
 
 This plugin is known to compile and work with CloudCompare
-commit `3eeee79f933dd7d5d1f79135f40bb38e12da1485`.
+commit `d917d67e688eebfdd0d5dde6ce2dbe634ae1e531`.
 
 Python 3.8 or more is required to build as a plugin.
 

--- a/wrapper/cccorelib/CMakeLists.txt
+++ b/wrapper/cccorelib/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CCCORELIB_PYTHON_IS_MASTER_PROJECT)
     GIT_REPOSITORY https://github.com/CloudCompare/CCCoreLib
     GIT_PROGRESS ON
     GIT_SHALLOW OFF
-    GIT_TAG 02d77076cff788cb7cf59ef92be28c4221f5cecc
+    GIT_TAG 729ed3d8ef8e32ab5a4877f0532ffb072bc649cb
   )
 
   FetchContent_GetProperties(CCCoreLib)

--- a/wrapper/pycc/CMakeLists.txt
+++ b/wrapper/pycc/CMakeLists.txt
@@ -35,7 +35,7 @@ if(PYCC_IS_MASTER_PROJECT)
     GIT_REPOSITORY https://github.com/CloudCompare/CloudCompare
     GIT_SUBMODULES "libs/qCC_db/extern/CCCoreLib"
     GIT_PROGRESS ON
-    GIT_TAG 3eeee79f933dd7d5d1f79135f40bb38e12da1485
+    GIT_TAG d917d67e688eebfdd0d5dde6ce2dbe634ae1e531
     GIT_SHALLOW OFF
   )
 

--- a/wrapper/pycc/src/qcc_db/ccRasterGrid.cpp
+++ b/wrapper/pycc/src/qcc_db/ccRasterGrid.cpp
@@ -100,6 +100,7 @@ void define_ccRasterGrid(py::module &m)
              "box"_a,
              "percentileValue"_a,
              "exportToOriginalCS"_a,
+             "appendGridSizeToSFNames"_a,
              "progressDialog"_a = nullptr)
         .def("fillWith",
              &ccRasterGrid::fillWith,


### PR DESCRIPTION
I added the missing argument present in ccRasterGrid header but not in ccRasterGrid.cpp that cause an error when python plugin is compiled with CloudCompare (see #78).